### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+ARG SERVER_NAME
+
+ARG VIRTUAL_REPO_NAME
+
 FROM ${SERVER_NAME}-${VIRTUAL_REPO_NAME}.jfrog.io/alpine:3.11.5
 
 CMD printf "\nCONGRATULATIONS!!!\n\nYou have just set up your first Docker repository with the new JFrog Platform!\n\n"


### PR DESCRIPTION
In docker 19.03.8,  to build an image with building arguments (--build-arg) they must be explicitly declared with ARG command in the Dockerfile.